### PR TITLE
Update IT translation

### DIFF
--- a/language/resource.language.it_it/strings.po
+++ b/language/resource.language.it_it/strings.po
@@ -67,7 +67,7 @@ msgstr "Personalizzazione Widget"
 #: /1080i/Includes_Shortcuts_Window.xml
 msgctxt "#31010"
 msgid "Welcome to the Arctic Fuse widget customisation screen!"
-msgstr "Benvenut@ nella schermata di personalizzazione dei widget di Arctic Fuse!"
+msgstr "Benvenutə nella schermata di personalizzazione dei widget di Arctic Fuse!"
 
 #: /1080i/Includes_Shortcuts_Window.xml
 msgctxt "#31011"
@@ -512,7 +512,7 @@ msgstr "Raccolte"
 #: /1080i/SkinSettings.xml
 msgctxt "#31109"
 msgid "Viewline"
-msgstr ""
+msgstr "Riga di identificazione widget/vista"
 
 msgctxt "#31111"
 msgid "Poster Row"
@@ -553,7 +553,7 @@ msgstr "Watchlist"
 #: /1080i/Includes_MediaFilter.xml
 msgctxt "#31123"
 msgid "On Deck"
-msgstr ""
+msgstr "Film e serie tv che aspettano te"
 
 msgctxt "#31124"
 msgid "Indicator"
@@ -1059,7 +1059,7 @@ msgstr "Colore Principale"
 
 msgctxt "#31248"
 msgid "Building includes"
-msgstr ""
+msgstr "Ricompilazione configurazioni delle disposizioni dei widget"
 
 msgctxt "#31249"
 msgid "Waiting for PVR"

--- a/language/resource.language.it_it/strings.po
+++ b/language/resource.language.it_it/strings.po
@@ -67,7 +67,7 @@ msgstr "Personalizzazione Widget"
 #: /1080i/Includes_Shortcuts_Window.xml
 msgctxt "#31010"
 msgid "Welcome to the Arctic Fuse widget customisation screen!"
-msgstr "Benvenutə nella schermata di personalizzazione dei widget di Arctic Fuse!"
+msgstr "Benvenut@ nella schermata di personalizzazione dei widget di Arctic Fuse!"
 
 #: /1080i/Includes_Shortcuts_Window.xml
 msgctxt "#31011"
@@ -150,7 +150,7 @@ msgstr "Modifica i widget utilizzati nella finestra di rierca"
 
 msgctxt "#31028"
 msgid "Outline"
-msgstr "Contorno"
+msgstr "Profilo"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31029"
@@ -684,7 +684,7 @@ msgstr "Nascondi"
 #: /1080i/SkinSettings.xml
 msgctxt "#31165"
 msgid "Seekbar behaviour on delayed pause"
-msgstr "Comportamento della barra di avanzamento sulla pausa prolungata"
+msgstr "Comportamento della barra di avanzamento per una pausa prolungata"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31166"
@@ -873,7 +873,7 @@ msgstr "Intestazione"
 #: /1080i/Includes_Labels.xml
 msgctxt "#31209"
 msgid "Boxes"
-msgstr "Box"
+msgstr "Riquadri"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31210"
@@ -1072,7 +1072,7 @@ msgstr "Orologio Analogico"
 
 msgctxt "#31252"
 msgid "Catch-up"
-msgstr "Raggiungi"
+msgstr "Recupero"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31253"
@@ -1453,7 +1453,7 @@ msgstr "Ricerca per"
 #: /1080i/Includes_Items.xml
 msgctxt "#31369"
 msgid "Video file"
-msgstr "File Video"
+msgstr "File video"
 
 #: /1080i/Custom_1172_Dialog_SideMenu.xml
 msgctxt "#31370"
@@ -1559,7 +1559,7 @@ msgstr "Esplora i widget"
 
 msgctxt "#31396"
 msgid "Recent Movies"
-msgstr "Film visti recente"
+msgstr "Film visti di recente"
 
 msgctxt "#31397"
 msgid "Recent Tv Shows"
@@ -1591,7 +1591,7 @@ msgstr "Serie TV che stai guardando"
 
 msgctxt "#31404"
 msgid "In-Progress Movies"
-msgstr "Film da finire di guardare"
+msgstr "Film da continuare a guardare"
 
 msgctxt "#31405"
 msgid "Top Albums"

--- a/language/resource.language.it_it/strings.po
+++ b/language/resource.language.it_it/strings.po
@@ -483,6 +483,11 @@ msgid "Gallery"
 msgstr "Galleria"
 
 #: /1080i/Includes_Labels.xml
+msgctxt "#31099"
+msgid "Last aired"
+msgstr "Ultima volta in onda"
+
+#: /1080i/Includes_Labels.xml
 msgctxt "#31102"
 msgid "Prebuilt Configuration"
 msgstr "Configurazione Preimpostata"

--- a/language/resource.language.it_it/strings.po
+++ b/language/resource.language.it_it/strings.po
@@ -1059,7 +1059,7 @@ msgstr "Colore Principale"
 
 msgctxt "#31248"
 msgid "Building includes"
-msgstr "Ricompilazione configurazioni delle disposizioni dei widget"
+msgstr "Ricompilazione includes"
 
 msgctxt "#31249"
 msgid "Waiting for PVR"


### PR DESCRIPTION
Some fixes and additions.

Still missing 3 strings, namely:

https://github.com/jurialmunkey/skin.arctic.fuse.2/blob/458158e652e38db32564508b9c841440e9e8cc7e/language/resource.language.it_it/strings.po#L508-L510
https://github.com/jurialmunkey/skin.arctic.fuse.2/blob/458158e652e38db32564508b9c841440e9e8cc7e/language/resource.language.it_it/strings.po#L549-L551
https://github.com/jurialmunkey/skin.arctic.fuse.2/blob/458158e652e38db32564508b9c841440e9e8cc7e/language/resource.language.it_it/strings.po#L1055-L1057

I noticed the first two are never used in any XML file, so couldn't determine the correct meaning and translation.
The last is apparently used on some loading but I'm still missing the context.
@jurialmunkey if you could tell me when that loading might occur I'd like to update at least the last string before you merge this.

Thanks