### PR TITLE
✨Display add-on title in the main hub header

### DIFF
--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -1450,7 +1450,7 @@
         <value condition="Window.IsVisible(1185)">$LOCALIZE[137]</value>
         <value condition="Window.IsVisible(filemanager)">$LOCALIZE[7]</value>
         <value condition="Window.IsVisible(MyMusicPlaylistEditor.xml)">$LOCALIZE[10503]</value>
-        <value condition="[Window.IsVisible(10025) | Window.IsVisible(10502)] + [Container.Content(addons) | !String.IsEmpty(Container.PluginName)]">$LOCALIZE[24000]</value>
+        <value condition="[Window.IsVisible(10025) | Window.IsVisible(10502)] + [Container.Content(addons) | !String.IsEmpty(Container.PluginName)]">$INFO[Container.FolderName]</value>
         <value condition="[Window.IsVisible(10025) | Window.IsVisible(10502)] + Container.Content(files)">$LOCALIZE[744]</value>
         <value condition="[Window.IsVisible(10025) | Window.IsVisible(10502)]">$LOCALIZE[14022]</value>
         <value condition="Window.IsVisible(tvchannels)">$LOCALIZE[10700]</value>


### PR DESCRIPTION
Very minor improvement tbh. If you're using widgets from multiple video add-ons, it can sometimes get confusing which source add-on a widget belongs to (because all you see is 'Add-on' in the header).