### PR TITLE
Add "Save" and "Cancel" buttons to PVR Guide Search menu

### DIFF
--- a/1080i/DialogPVRGuideSearch.xml
+++ b/1080i/DialogPVRGuideSearch.xml
@@ -217,9 +217,23 @@
                         <include content="DialogInfo_ExpandedButton">
                             <param name="id">9003</param>
                             <param name="groupid">9103</param>
+                            <param name="label">$LOCALIZE[190]</param>
+                            <param name="icon">special://skin/extras/icons/files.png</param>
+                            <onclick>SendClick(29)</onclick>
+                        </include>
+                        <include content="DialogInfo_ExpandedButton">
+                            <param name="id">9004</param>
+                            <param name="groupid">9104</param>
                             <param name="label">$LOCALIZE[13007]</param>
                             <param name="icon">special://skin/extras/icons/triangle-exclamation.png</param>
                             <onclick>SendClick(28)</onclick>
+                        </include>
+                        <include content="DialogInfo_ExpandedButton">
+                            <param name="id">9005</param>
+                            <param name="groupid">9105</param>
+                            <param name="label">$LOCALIZE[222]</param>
+                            <param name="icon">special://skin/extras/icons/circle-xmark.png</param>
+                            <onclick>SendClick(25)</onclick>
                         </include>
 
                     </control>


### PR DESCRIPTION
These two buttons were missing from the menu.

BEFORE
![before](https://github.com/user-attachments/assets/9ab9fd8d-3695-4468-b1b3-5bc1be0f4deb)

AFTER
![after](https://github.com/user-attachments/assets/9ddbedfe-c866-4021-a36b-68a060642ca4)

What it looks like in Estuary
![estuary](https://github.com/user-attachments/assets/4cfa7fc7-333a-4ab9-8b52-1279ee2ef6cf)
