### PR TITLE
Show tv program image when playing a recording

### DIFF
--- a/1080i/Includes_Images.xml
+++ b/1080i/Includes_Images.xml
@@ -119,6 +119,7 @@
 
     <variable name="Image_OSD_Landscape">
         <value condition="!String.IsEmpty(Pvr.EPGEventIcon)">$INFO[Pvr.EPGEventIcon]</value>
+        <value condition="!String.IsEmpty(Player.Art(thumb)) + PVR.IsPlayingRecording">$INFO[Player.Art(thumb)]</value>
         <value condition="!String.IsEmpty(VideoPlayer.Art(landscape))">$INFO[VideoPlayer.Art(landscape)]</value>
         <value condition="!String.IsEmpty(VideoPlayer.Art(tvshow.landscape))">$INFO[VideoPlayer.Art(tvshow.landscape)]</value>
         <value condition="!String.IsEmpty(Player.Art(landscape))">$INFO[Player.Art(landscape)]</value>


### PR DESCRIPTION
Before
![screenshot00008](https://github.com/user-attachments/assets/23a54d60-8056-4e5b-8550-a88fb3da944b)

After
![screenshot00007](https://github.com/user-attachments/assets/dc3b9eef-c3d7-48e4-a9cc-8545f9ac9e4f)

Currently it shows the channel icon in the osd info when playing a recording. This pull request makes the tv program image visible if available like it does when playing a live tv channel.

Pvr.EPGEventIcon is empty for recordings.
Player.Art(thumb) has the program image.
Player.Art(icon) has the channel icon.
