### PR TITLE
Fix duplicate tv program title in pvr landscape views

### DIFF
--- a/1080i/script-skinvariables-labels-includes.xml
+++ b/1080i/script-skinvariables-labels-includes.xml
@@ -1087,7 +1087,8 @@
         <value condition="!String.IsEmpty(Container(50).ListItem.Property(role))">$INFO[Container(50).ListItem.Property(role)]$INFO[Container(50).ListItem.Property(episodes), (,)]</value>
         <value condition="!String.IsEmpty(Container(50).ListItem.Property(character))">$INFO[Container(50).ListItem.Property(character)]$INFO[Container(50).ListItem.Property(episodes), (,)]</value>
         <value condition="!String.IsEmpty(Container(50).ListItem.Property(department))">$INFO[Container(50).ListItem.Property(department)]$INFO[Container(50).ListItem.Property(episodes), (,)]</value>
-        <value condition="!String.IsEmpty(Container(50).ListItem.ChannelNumberLabel) + !String.IsEmpty(Container(50).ListItem.Title)">$INFO[Container(50).ListItem.Title]</value>
+        <value condition="!String.IsEmpty(Container(50).ListItem.ChannelNumberLabel) + !String.IsEmpty(Container(50).ListItem.Title) + !String.IsEqual(Container(50).ListItem.Title,Container(50).ListItem.Label)">$INFO[Container(50).ListItem.Title]</value>
+        <value condition="!String.IsEmpty(Container(50).ListItem.ChannelNumberLabel) + !String.IsEmpty(Container(50).ListItem.ChannelName)">$INFO[Container(50).ListItem.ChannelName]</value>
         <value condition="!String.IsEmpty(Container(50).ListItem.TvShowTitle) + !String.IsEqual(Container(50).ListItem.Title,Container(50).ListItem.TVShowTitle) + !String.IsEqual(Container(50).ListItem.DBType,tvshow)">$INFO[Container(50).ListItem.TvShowTitle]</value>
         <value condition="!String.IsEmpty(Container(50).ListItem.AlbumArtist) + !String.IsEqual(Container(50).ListItem.Title,Container(50).ListItem.AlbumArtist) + !String.IsEqual(Container(50).ListItem.DBType,artist)">$INFO[Container(50).ListItem.AlbumArtist]</value>
         <value condition="!String.IsEmpty(Container(50).ListItem.Artist) + !String.IsEqual(Container(50).ListItem.Title,Container(50).ListItem.Artist) + !String.IsEqual(Container(50).ListItem.DBType,artist)">$INFO[Container(50).ListItem.Artist]</value>
@@ -1109,7 +1110,8 @@
         <value condition="!String.IsEmpty(Container(503).ListItem.Property(role))">$INFO[Container(503).ListItem.Property(role)]$INFO[Container(503).ListItem.Property(episodes), (,)]</value>
         <value condition="!String.IsEmpty(Container(503).ListItem.Property(character))">$INFO[Container(503).ListItem.Property(character)]$INFO[Container(503).ListItem.Property(episodes), (,)]</value>
         <value condition="!String.IsEmpty(Container(503).ListItem.Property(department))">$INFO[Container(503).ListItem.Property(department)]$INFO[Container(503).ListItem.Property(episodes), (,)]</value>
-        <value condition="!String.IsEmpty(Container(503).ListItem.ChannelNumberLabel) + !String.IsEmpty(Container(503).ListItem.Title)">$INFO[Container(503).ListItem.Title]</value>
+        <value condition="!String.IsEmpty(Container(503).ListItem.ChannelNumberLabel) + !String.IsEmpty(Container(503).ListItem.Title) + !String.IsEqual(Container(503).ListItem.Title,Container(503).ListItem.Label)">$INFO[Container(503).ListItem.Title]</value>
+        <value condition="!String.IsEmpty(Container(503).ListItem.ChannelNumberLabel) + !String.IsEmpty(Container(503).ListItem.ChannelName)">$INFO[Container(503).ListItem.ChannelName]</value>
         <value condition="!String.IsEmpty(Container(503).ListItem.TvShowTitle) + !String.IsEqual(Container(503).ListItem.Title,Container(503).ListItem.TVShowTitle) + !String.IsEqual(Container(503).ListItem.DBType,tvshow)">$INFO[Container(503).ListItem.TvShowTitle]</value>
         <value condition="!String.IsEmpty(Container(503).ListItem.AlbumArtist) + !String.IsEqual(Container(503).ListItem.Title,Container(503).ListItem.AlbumArtist) + !String.IsEqual(Container(503).ListItem.DBType,artist)">$INFO[Container(503).ListItem.AlbumArtist]</value>
         <value condition="!String.IsEmpty(Container(503).ListItem.Artist) + !String.IsEqual(Container(503).ListItem.Title,Container(503).ListItem.Artist) + !String.IsEqual(Container(503).ListItem.DBType,artist)">$INFO[Container(503).ListItem.Artist]</value>
@@ -1131,7 +1133,8 @@
         <value condition="!String.IsEmpty(Container(51).ListItem.Property(role))">$INFO[Container(51).ListItem.Property(role)]$INFO[Container(51).ListItem.Property(episodes), (,)]</value>
         <value condition="!String.IsEmpty(Container(51).ListItem.Property(character))">$INFO[Container(51).ListItem.Property(character)]$INFO[Container(51).ListItem.Property(episodes), (,)]</value>
         <value condition="!String.IsEmpty(Container(51).ListItem.Property(department))">$INFO[Container(51).ListItem.Property(department)]$INFO[Container(51).ListItem.Property(episodes), (,)]</value>
-        <value condition="!String.IsEmpty(Container(51).ListItem.ChannelNumberLabel) + !String.IsEmpty(Container(51).ListItem.Title)">$INFO[Container(51).ListItem.Title]</value>
+        <value condition="!String.IsEmpty(Container(51).ListItem.ChannelNumberLabel) + !String.IsEmpty(Container(51).ListItem.Title) + !String.IsEqual(Container(51).ListItem.Title,Container(51).ListItem.Label)">$INFO[Container(51).ListItem.Title]</value>
+        <value condition="!String.IsEmpty(Container(51).ListItem.ChannelNumberLabel) + !String.IsEmpty(Container(51).ListItem.ChannelName)">$INFO[Container(51).ListItem.ChannelName]</value>
         <value condition="!String.IsEmpty(Container(51).ListItem.TvShowTitle) + !String.IsEqual(Container(51).ListItem.Title,Container(51).ListItem.TVShowTitle) + !String.IsEqual(Container(51).ListItem.DBType,tvshow)">$INFO[Container(51).ListItem.TvShowTitle]</value>
         <value condition="!String.IsEmpty(Container(51).ListItem.AlbumArtist) + !String.IsEqual(Container(51).ListItem.Title,Container(51).ListItem.AlbumArtist) + !String.IsEqual(Container(51).ListItem.DBType,artist)">$INFO[Container(51).ListItem.AlbumArtist]</value>
         <value condition="!String.IsEmpty(Container(51).ListItem.Artist) + !String.IsEqual(Container(51).ListItem.Title,Container(51).ListItem.Artist) + !String.IsEqual(Container(51).ListItem.DBType,artist)">$INFO[Container(51).ListItem.Artist]</value>
@@ -1153,7 +1156,8 @@
         <value condition="!String.IsEmpty(Container(513).ListItem.Property(role))">$INFO[Container(513).ListItem.Property(role)]$INFO[Container(513).ListItem.Property(episodes), (,)]</value>
         <value condition="!String.IsEmpty(Container(513).ListItem.Property(character))">$INFO[Container(513).ListItem.Property(character)]$INFO[Container(513).ListItem.Property(episodes), (,)]</value>
         <value condition="!String.IsEmpty(Container(513).ListItem.Property(department))">$INFO[Container(513).ListItem.Property(department)]$INFO[Container(513).ListItem.Property(episodes), (,)]</value>
-        <value condition="!String.IsEmpty(Container(513).ListItem.ChannelNumberLabel) + !String.IsEmpty(Container(513).ListItem.Title)">$INFO[Container(513).ListItem.Title]</value>
+        <value condition="!String.IsEmpty(Container(513).ListItem.ChannelNumberLabel) + !String.IsEmpty(Container(513).ListItem.Title) + !String.IsEqual(Container(513).ListItem.Title,Container(513).ListItem.Label)">$INFO[Container(513).ListItem.Title]</value>
+        <value condition="!String.IsEmpty(Container(513).ListItem.ChannelNumberLabel) + !String.IsEmpty(Container(513).ListItem.ChannelName)">$INFO[Container(513).ListItem.ChannelName]</value>
         <value condition="!String.IsEmpty(Container(513).ListItem.TvShowTitle) + !String.IsEqual(Container(513).ListItem.Title,Container(513).ListItem.TVShowTitle) + !String.IsEqual(Container(513).ListItem.DBType,tvshow)">$INFO[Container(513).ListItem.TvShowTitle]</value>
         <value condition="!String.IsEmpty(Container(513).ListItem.AlbumArtist) + !String.IsEqual(Container(513).ListItem.Title,Container(513).ListItem.AlbumArtist) + !String.IsEqual(Container(513).ListItem.DBType,artist)">$INFO[Container(513).ListItem.AlbumArtist]</value>
         <value condition="!String.IsEmpty(Container(513).ListItem.Artist) + !String.IsEqual(Container(513).ListItem.Title,Container(513).ListItem.Artist) + !String.IsEqual(Container(513).ListItem.DBType,artist)">$INFO[Container(513).ListItem.Artist]</value>
@@ -1175,7 +1179,8 @@
         <value condition="!String.IsEmpty(ListItem.Property(role))">$INFO[ListItem.Property(role)]$INFO[ListItem.Property(episodes), (,)]</value>
         <value condition="!String.IsEmpty(ListItem.Property(character))">$INFO[ListItem.Property(character)]$INFO[ListItem.Property(episodes), (,)]</value>
         <value condition="!String.IsEmpty(ListItem.Property(department))">$INFO[ListItem.Property(department)]$INFO[ListItem.Property(episodes), (,)]</value>
-        <value condition="!String.IsEmpty(ListItem.ChannelNumberLabel) + !String.IsEmpty(ListItem.Title)">$INFO[ListItem.Title]</value>
+        <value condition="!String.IsEmpty(ListItem.ChannelNumberLabel) + !String.IsEmpty(ListItem.Title) + !String.IsEqual(ListItem.Title,ListItem.Label)">$INFO[ListItem.Title]</value>
+        <value condition="!String.IsEmpty(ListItem.ChannelNumberLabel) + !String.IsEmpty(ListItem.ChannelName)">$INFO[ListItem.ChannelName]</value>
         <value condition="!String.IsEmpty(ListItem.TvShowTitle) + !String.IsEqual(ListItem.Title,ListItem.TVShowTitle) + !String.IsEqual(ListItem.DBType,tvshow)">$INFO[ListItem.TvShowTitle]</value>
         <value condition="!String.IsEmpty(ListItem.AlbumArtist) + !String.IsEqual(ListItem.Title,ListItem.AlbumArtist) + !String.IsEqual(ListItem.DBType,artist)">$INFO[ListItem.AlbumArtist]</value>
         <value condition="!String.IsEmpty(ListItem.Artist) + !String.IsEqual(ListItem.Title,ListItem.Artist) + !String.IsEqual(ListItem.DBType,artist)">$INFO[ListItem.Artist]</value>

--- a/shortcuts/skinvariables-labels.xml
+++ b/shortcuts/skinvariables-labels.xml
@@ -60,7 +60,8 @@
         <value condition="!String.IsEmpty({listitem}.Property(role))">$INFO[{listitem}.Property(role)]$INFO[{listitem}.Property(episodes), (,)]</value>
         <value condition="!String.IsEmpty({listitem}.Property(character))">$INFO[{listitem}.Property(character)]$INFO[{listitem}.Property(episodes), (,)]</value>
         <value condition="!String.IsEmpty({listitem}.Property(department))">$INFO[{listitem}.Property(department)]$INFO[{listitem}.Property(episodes), (,)]</value>
-        <value condition="!String.IsEmpty({listitem}.ChannelNumberLabel) + !String.IsEmpty({listitem}.Title)">$INFO[{listitem}.Title]</value>
+        <value condition="!String.IsEmpty({listitem}.ChannelNumberLabel) + !String.IsEmpty({listitem}.Title) + !String.IsEqual({listitem}.Title,{listitem}.Label)">$INFO[{listitem}.Title]</value>
+        <value condition="!String.IsEmpty({listitem}.ChannelNumberLabel) + !String.IsEmpty({listitem}.ChannelName)">$INFO[{listitem}.ChannelName]</value>
         <value condition="!String.IsEmpty({listitem}.TvShowTitle) + !String.IsEqual({listitem}.Title,{listitem}.TVShowTitle) + !String.IsEqual({listitem}.DBType,tvshow)">$INFO[{listitem}.TvShowTitle]</value>
         <value condition="!String.IsEmpty({listitem}.AlbumArtist) + !String.IsEqual({listitem}.Title,{listitem}.AlbumArtist) + !String.IsEqual({listitem}.DBType,artist)">$INFO[{listitem}.AlbumArtist]</value>
         <value condition="!String.IsEmpty({listitem}.Artist) + !String.IsEqual({listitem}.Title,{listitem}.Artist) + !String.IsEqual({listitem}.DBType,artist)">$INFO[{listitem}.Artist]</value>


### PR DESCRIPTION
Before
![screenshot00009](https://github.com/user-attachments/assets/fe621c41-4601-44a9-881c-752ba2048d11)

After
![screenshot00010](https://github.com/user-attachments/assets/e3347e73-c1aa-435e-9304-4c3db584517d)

The upper label in PVR widgets and landscape views contains sometimes the channel name and sometimes the program title. This causes the lower label to be a duplicate of the upper label and then the program title is shown twice.

This pull request compares the label and a title and if they are the same it shows the channel name instead.