### PR TITLE
Update strings.po

### DIFF
--- a/language/resource.language.de_de/strings.po
+++ b/language/resource.language.de_de/strings.po
@@ -2157,7 +2157,7 @@ msgstr "Jede Kategorie kann ihr eigenes Set vertikal gestapelter Widgets definie
 #: /1080i/Includes_Labels.xml
 msgctxt "#31490"
 msgid "Cancelled"
-msgstr "Abgebrochen"
+msgstr "Abgesetzt"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31491"


### PR DESCRIPTION
Just a small fix. 
The current translation is the same as  "The show was aborted", in the context of saying a show was cancelled, in Germany we say "Abgesetzt" instead of "Abgebrochen".