### PR TITLE
Change OSD title for Recordings

### DIFF
--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -1310,7 +1310,7 @@
 
     <variable name="Label_OSD_Title">
         <value condition="!String.IsEmpty(MusicPlayer.Album)">$INFO[MusicPlayer.Album]</value>
-        <value condition="!String.IsEmpty(VideoPlayer.TvShowTitle)">$INFO[VideoPlayer.TvShowTitle]</value>
+        <value condition="!String.IsEmpty(VideoPlayer.TvShowTitle) + String.IsEmpty(VideoPlayer.ChannelNumberLabel)">$INFO[VideoPlayer.TvShowTitle]</value>
         <value condition="!String.IsEmpty(VideoPlayer.Title)">$INFO[VideoPlayer.Title]</value>
         <value condition="!String.IsEmpty(VideoPlayer.Label)">$INFO[VideoPlayer.Label]</value>
         <value condition="!String.IsEmpty(Player.Title)">$INFO[Player.Title]</value>


### PR DESCRIPTION
Shows the program title instead of episode title in OSD for recordings. Makes it consistent with osd in live tv, movies and episodes.

OSD Info
![screenshot00012](https://github.com/user-attachments/assets/d7e018c8-f904-4b02-8e35-addc2c1c810b)

OSD
![screenshot00015](https://github.com/user-attachments/assets/c6c745c3-c021-4116-bc8e-0341f7f526f6)
