### PR TITLE
⚡Use EndTimeResume for accurate "Ends At" time

### DIFF
--- a/1080i/Includes_Info.xml
+++ b/1080i/Includes_Info.xml
@@ -1604,13 +1604,11 @@
                         <param name="dbtype_04">episode</param>
                         <param name="dbtype_05">video</param>
                     </include>
-                    <param name="items_03">true</param>
-                    <param name="label_01">$INFO[$PARAM[container]ListItem.EndTime,$LOCALIZE[31184] ,]</param>
-                    <param name="label_02">$INFO[Window(Home).Property(TMDbHelper.ListItem.base_endtime),$LOCALIZE[31184] ,]</param>
-                    <param name="label_03">$INFO[Window(Home).Property(TMDbHelper.ListItem.EndTime),$LOCALIZE[31184] ,]</param>
-                    <param name="visible_01">!String.IsEmpty($PARAM[container]ListItem.EndTime) + !String.IsEqual($PARAM[container]ListItem.EndTime,System.Time)</param>
-                    <param name="visible_02">!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.base_endtime)) + !String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.base_endtime),System.Time)</param>
-                    <param name="visible_03">!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.EndTime)) + !String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.EndTime),System.Time)</param>
+                    <param name="items_02">true</param>
+                    <param name="label_01">$INFO[$PARAM[container]ListItem.EndTimeResume,$LOCALIZE[31184] ,]</param>
+                    <param name="label_02">$INFO[Window(Home).Property(TMDbHelper.ListItem.base_endtimeresume),$LOCALIZE[31184] ,]</param>                    
+                    <param name="visible_01">!String.IsEmpty($PARAM[container]ListItem.EndTimeResume) + !String.IsEqual($PARAM[container]ListItem.EndTimeResume,System.Time)</param>
+                    <param name="visible_02">!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.base_endtimeresume)) + !String.IsEqual(Window(Home).Property(TMDbHelper.ListItem.base_endtimeresume),System.Time)</param>                    
                     <param name="textcolor">$PARAM[colordiffuse]_70</param>
                 </include>
 

--- a/extras/tmdbhelper/baseitem.json
+++ b/extras/tmdbhelper/baseitem.json
@@ -5,6 +5,7 @@
     "year": {"infolabels": ["year", "Property(artist_yearsactive)"]},
     "premiered": {"infolabels": ["premiered"]},
     "endtime": {"infolabels": ["endtime"]},
+    "endtimeresume": {"infolabels": ["endtimeresume"]},
     "duration": {"infolabels": ["duration"]},
     "duration_h": {"infolabels": ["duration(h)"]},
     "duration_m": {"infolabels": ["duration(m)"]},


### PR DESCRIPTION
Works well with TMDbHelper widgets and other 3rd Party add-ons (provided they set the resumepoint in time and not as a float)