### PR TITLE
✨ Add audio codec info label

### DIFF
--- a/1080i/Includes_DialogInfo.xml
+++ b/1080i/Includes_DialogInfo.xml
@@ -1486,7 +1486,7 @@
 
                     <!-- Codecs -->
                     <include content="Object_InfoCircle">
-                        <param name="name">[UPPERCASE]$INFO[ListItem.VideoResolution,, • ]$INFO[ListItem.VideoCodec]$INFO[ListItem.VideoAspect, • ,:1]$INFO[ListItem.AudioCodec, • ,]$VAR[Label_ListItem_AudioChannels, • ,][/UPPERCASE]</param>
+                        <param name="name">[UPPERCASE]$INFO[ListItem.VideoResolution,, • ]$INFO[ListItem.VideoAspect,,:1]$VAR[Label_ListItem_AudioCodec, • ,]$VAR[Label_ListItem_AudioChannels, • ,][/UPPERCASE]</param>
                         <param name="role">$INFO[ListItem.VideoVersionName]</param>
                         <param name="icon">special://skin/extras/icons/photo-film.png</param>
                         <param name="fallback_role">$LOCALIZE[31207]</param>

--- a/1080i/Includes_DialogSelect.xml
+++ b/1080i/Includes_DialogSelect.xml
@@ -532,15 +532,15 @@
                                     <param name="label">$INFO[Container($PARAM[id]).ListItem.VideoAspect,,:1]</param>
                                     <param name="visible">!String.IsEmpty(Container($PARAM[id]).ListItem.VideoAspect)</param>
                                 </include>
+                                <include content="Info_Line_AudioCodec">
+                                    <param name="colordiffuse">main_fg_90</param>
+                                    <param name="listitem_audiocodec">Container($PARAM[id]).ListItem.AudioCodec</param>
+                                    <param name="visible">!String.IsEmpty(Container($PARAM[id]).ListItem.AudioCodec)</param>
+                                </include>
                                 <include content="Info_Line_AudioChannels">
                                     <param name="colordiffuse">main_fg_90</param>
                                     <param name="listitem_audiochannels">Container($PARAM[id]).ListItem.AudioChannels</param>
                                     <param name="visible">!String.IsEmpty(Container($PARAM[id]).ListItem.AudioChannels)</param>
-                                </include>
-                                <include content="Info_Line_VideoQuality_Object">
-                                    <param name="colordiffuse">main_fg_90</param>
-                                    <param name="label">$INFO[Container($PARAM[id]).ListItem.AudioCodec]</param>
-                                    <param name="visible">!String.IsEmpty(Container($PARAM[id]).ListItem.AudioCodec)</param>
                                 </include>
                                 <include content="Info_Line_VideoQuality_Object">
                                     <param name="colordiffuse">main_fg_90</param>

--- a/1080i/Includes_Info.xml
+++ b/1080i/Includes_Info.xml
@@ -1265,6 +1265,106 @@
             </include>
         </definition>
     </include>
+	
+    <include name="Info_Line_AudioCodec">
+        <definition>
+            <include content="Info_Line_VideoQuality_Object">
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="label">AAC</param>
+                <param name="visible">$PARAM[visible] + String.IsEqual($PARAM[listitem_audiocodec],aac) | String.IsEqual($PARAM[listitem_audiocodec],aac_latm)</param>
+            </include>
+            <include content="Info_Line_VideoQuality_Object">
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="label">Dolby Digital</param>
+                <param name="visible">$PARAM[visible] + String.IsEqual($PARAM[listitem_audiocodec],ac3) | String.IsEqual($PARAM[listitem_audiocodec],dolbydigital)</param>
+            </include>
+            <include content="Info_Line_VideoQuality_Object">
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="label">AVC</param>
+                <param name="visible">$PARAM[visible] + String.IsEqual($PARAM[listitem_audiocodec],avc)</param>
+            </include>
+            <include content="Info_Line_VideoQuality_Object">
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="label">DTS</param>
+                <param name="visible">$PARAM[visible] + String.IsEqual($PARAM[listitem_audiocodec],dca) | String.IsEqual($PARAM[listitem_audiocodec],dts)</param>
+            </include>
+            <include content="Info_Line_VideoQuality_Object">
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="label">DTS-HD</param>
+                <param name="visible">$PARAM[visible] + String.IsEqual($PARAM[listitem_audiocodec],dtshd)</param>
+            </include>
+            <include content="Info_Line_VideoQuality_Object">
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="label">DTS-HD MA</param>
+                <param name="visible">$PARAM[visible] + String.IsEqual($PARAM[listitem_audiocodec],dtshd_ma)</param>
+            </include>
+            <include content="Info_Line_VideoQuality_Object">
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="label">DTS-HD HRA</param>
+                <param name="visible">$PARAM[visible] + String.IsEqual($PARAM[listitem_audiocodec],dtshd_hra)</param>
+            </include>
+            <include content="Info_Line_VideoQuality_Object">
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="label">DTS:X MA</param>
+                <param name="visible">$PARAM[visible] + String.IsEqual($PARAM[listitem_audiocodec],dtshd_ma_x)</param>
+            </include>
+            <include content="Info_Line_VideoQuality_Object">
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="label">DTS:X (IMAX)</param>
+                <param name="visible">$PARAM[visible] + String.IsEqual($PARAM[listitem_audiocodec],dtshd_ma_x_imax)</param>
+            </include>
+            <include content="Info_Line_VideoQuality_Object">
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="label">Dolby Digital+</param>
+                <param name="visible">$PARAM[visible] + String.IsEqual($PARAM[listitem_audiocodec],eac3)</param>
+            </include>
+            <include content="Info_Line_VideoQuality_Object">
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="label">Dolby Atmos</param>
+                <param name="visible">$PARAM[visible] + String.IsEqual($PARAM[listitem_audiocodec],eac3_ddp_atmos)</param>
+            </include>
+            <include content="Info_Line_VideoQuality_Object">
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="label">FLAC</param>
+                <param name="visible">$PARAM[visible] + String.IsEqual($PARAM[listitem_audiocodec],flac)</param>
+            </include>
+            <include content="Info_Line_VideoQuality_Object">
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="label">MP3</param>
+                <param name="visible">$PARAM[visible] + String.IsEqual($PARAM[listitem_audiocodec],mp3) | String.IsEqual($PARAM[listitem_audiocodec],mp3float)</param>
+            </include>
+            <include content="Info_Line_VideoQuality_Object">
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="label">OGG</param>
+                <param name="visible">$PARAM[visible] + String.IsEqual($PARAM[listitem_audiocodec],ogg)</param>
+            </include>
+            <include content="Info_Line_VideoQuality_Object">
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="label">OPUS</param>
+                <param name="visible">$PARAM[visible] + String.IsEqual($PARAM[listitem_audiocodec],opus)</param>
+            </include>
+            <include content="Info_Line_VideoQuality_Object">
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="label">PCM</param>
+                <param name="visible">$PARAM[visible] + String.IsEqual($PARAM[listitem_audiocodec],pcm) | String.IsEqual($PARAM[listitem_audiocodec],pcm_bluray) | String.IsEqual($PARAM[listitem_audiocodec],pcm_s16le) | String.IsEqual($PARAM[listitem_audiocodec],pcm_s24le)</param>
+            </include>
+            <include content="Info_Line_VideoQuality_Object">
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="label">Dolby TrueHD</param>
+                <param name="visible">$PARAM[visible] + String.IsEqual($PARAM[listitem_audiocodec],truehd)</param>
+            </include>
+            <include content="Info_Line_VideoQuality_Object">
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="label">Dolby Atmos</param>
+                <param name="visible">$PARAM[visible] + String.IsEqual($PARAM[listitem_audiocodec],truehd_atmos)</param>
+            </include>
+            <include content="Info_Line_VideoQuality_Object">
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="label">WAV</param>
+                <param name="visible">$PARAM[visible] + String.IsEqual($PARAM[listitem_audiocodec],wav)</param>
+            </include>
+        </definition>
+    </include>
 
     <include name="Info_Line_AudioChannels">
         <definition>
@@ -1344,6 +1444,11 @@
                 <param name="is_hdr">[String.IsEqual($PARAM[listitem_hdrtype],hdr10)]</param>
                 <param name="is_hlg">[String.IsEqual($PARAM[listitem_hdrtype],hlg)]</param>
             </include>
+            <include content="Info_Line_AudioCodec" condition="!Skin.HasSetting(Infoline.DisableAudioCodec)">
+                <param name="colordiffuse">$PARAM[colordiffuse]</param>
+                <param name="listitem_audiocodec">$PARAM[listitem_audiocodec]</param>
+                <param name="visible">$PARAM[visible] + !String.IsEmpty($PARAM[listitem_audiocodec])</param>
+            </include>
             <include content="Info_Line_AudioChannels" condition="!Skin.HasSetting(Infoline.DisableAudioChannels)">
                 <param name="colordiffuse">$PARAM[colordiffuse]</param>
                 <param name="listitem_audiochannels">$PARAM[listitem_audiochannels]</param>
@@ -1386,6 +1491,7 @@
                     <param name="listitem_videoresolution">$PARAM[container]ListItem.VideoResolution</param>
                     <param name="listitem_dbtype">$PARAM[container]ListItem.DBType</param>
                     <param name="listitem_hdrtype">$PARAM[container]ListItem.HdrType</param>
+                    <param name="listitem_audiocodec">$PARAM[container]ListItem.AudioCodec</param>
                     <param name="listitem_audiochannels">$PARAM[container]ListItem.AudioChannels</param>
                     <param name="visible">!Integer.IsEqual(Container($PARAM[grouplistid]).NumItems,0) + Integer.IsEqual(Window.Property(TMDBHelper.WidgetContainer),System.CurrentControlID)</param>
                 </include>
@@ -1397,6 +1503,7 @@
                     <param name="listitem_videoresolution">Window(Home).Property(TMDbHelper.ListItem.base_videoresolution)</param>
                     <param name="listitem_dbtype">Window(Home).Property(TMDbHelper.ListItem.base_dbtype)</param>
                     <param name="listitem_hdrtype">Window(Home).Property(TMDbHelper.ListItem.base_hdrtype)</param>
+                    <param name="listitem_audiocodec">Window(Home).Property(TMDbHelper.ListItem.base_audiocodec)</param>
                     <param name="listitem_audiochannels">Window(Home).Property(TMDbHelper.ListItem.base_audiochannels)</param>
                     <param name="visible">!Integer.IsEqual(Container($PARAM[grouplistid]).NumItems,0) + !Integer.IsEqual(Window.Property(TMDBHelper.WidgetContainer),System.CurrentControlID)</param>
                 </include>

--- a/1080i/Includes_Items.xml
+++ b/1080i/Includes_Items.xml
@@ -204,8 +204,16 @@
             <selected>!Skin.HasSetting(Infoline.DisableHDR)</selected>
             <label>HDR</label>
         </include>
-        <include content="Settings_Button" description="Audio Channels">
+        <include content="Settings_Button" description="Audio Codec">
             <param name="id">8003</param>
+            <param name="control">radiobutton</param>
+            <param name="dialog">true</param>
+            <onclick>Skin.ToggleSetting(Infoline.DisableAudioCodec)</onclick>
+            <selected>!Skin.HasSetting(Infoline.DisableAudioCodec)</selected>
+            <label>$LOCALIZE[31549]</label>
+        </include>
+        <include content="Settings_Button" description="Audio Channels">
+            <param name="id">8004</param>
             <param name="control">radiobutton</param>
             <param name="dialog">true</param>
             <onclick>Skin.ToggleSetting(Infoline.DisableAudioChannels)</onclick>
@@ -213,7 +221,7 @@
             <label>$LOCALIZE[21444]</label>
         </include>
         <include content="Settings_Button" description="Version">
-            <param name="id">8004</param>
+            <param name="id">8005</param>
             <param name="control">radiobutton</param>
             <param name="dialog">true</param>
             <onclick>Skin.ToggleSetting(Infoline.DisableVersion)</onclick>
@@ -221,7 +229,7 @@
             <label>$LOCALIZE[40013]</label>
         </include>
         <include content="Settings_Button" description="Collection">
-            <param name="id">8005</param>
+            <param name="id">8006</param>
             <param name="control">radiobutton</param>
             <param name="dialog">true</param>
             <onclick>Skin.ToggleSetting(Infoline.DisableCollection)</onclick>
@@ -229,11 +237,12 @@
             <label>$LOCALIZE[31108]</label>
         </include>
         <include content="Settings_Button" description="None">
-            <param name="id">8006</param>
+            <param name="id">8007</param>
             <param name="control">button</param>
             <param name="dialog">true</param>
             <onclick>Skin.SetBool(Infoline.DisableSource)</onclick>
             <onclick>Skin.SetBool(Infoline.DisableHDR)</onclick>
+            <onclick>Skin.SetBool(Infoline.DisableAudioCodec)</onclick>
             <onclick>Skin.SetBool(Infoline.DisableAudioChannels)</onclick>
             <onclick>Skin.SetBool(Infoline.DisableVersion)</onclick>
             <onclick>Skin.SetBool(Infoline.DisableCollection)</onclick>

--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -469,8 +469,8 @@
     </variable>
 
     <variable name="Label_Setting_AdditionalTags">       
-        <value condition="Skin.HasSetting(Info.EnablePillboxStyle) + Skin.HasSetting(Infoline.DisableSource) + Skin.HasSetting(Infoline.DisableHDR) + Skin.HasSetting(Infoline.DisableAudioChannels) + Skin.HasSetting(Infoline.DisableVersion) + Skin.HasSetting(Infoline.DisableCollection)">$LOCALIZE[16018]</value> <!--  NONE -->
-        <value>$VAR[Label_Setting_AdditionalTags_Source,   ,]$VAR[Label_Setting_AdditionalTags_HDR,   ,]$VAR[Label_Setting_AdditionalTags_AudioChannels,   ,]$VAR[Label_Setting_AdditionalTags_Version,   ,]$VAR[Label_Setting_AdditionalTags_Collection,   ,]</value>
+        <value condition="Skin.HasSetting(Info.EnablePillboxStyle) + Skin.HasSetting(Infoline.DisableSource) + Skin.HasSetting(Infoline.DisableHDR) + Skin.HasSetting(Infoline.DisableAudioCodec) + Skin.HasSetting(Infoline.DisableAudioChannels) + Skin.HasSetting(Infoline.DisableVersion) + Skin.HasSetting(Infoline.DisableCollection)">$LOCALIZE[16018]</value> <!--  NONE -->
+        <value>$VAR[Label_Setting_AdditionalTags_Source,   ,]$VAR[Label_Setting_AdditionalTags_HDR,   ,]$VAR[Label_Setting_AdditionalTags_AudioCodec,   ,]$VAR[Label_Setting_AdditionalTags_AudioChannels,   ,]$VAR[Label_Setting_AdditionalTags_Version,   ,]$VAR[Label_Setting_AdditionalTags_Collection,   ,]</value>
     </variable>
 
     <variable name="Label_Setting_AdditionalTags_Source">
@@ -479,6 +479,10 @@
 
     <variable name="Label_Setting_AdditionalTags_HDR">
         <value condition="!Skin.HasSetting(Infoline.DisableHDR)">HDR</value>
+    </variable>
+	
+    <variable name="Label_Setting_AdditionalTags_AudioCodec">
+        <value condition="!Skin.HasSetting(Infoline.DisableAudioCodec)">$LOCALIZE[31549]</value>
     </variable>
 
     <variable name="Label_Setting_AdditionalTags_AudioChannels">
@@ -963,6 +967,13 @@
         <value condition="String.IsEqual(VideoPlayer.HdrType,hlg)">HLG</value>
         <value>SDR</value>
     </variable>
+	
+    <variable name="Label_OSD_VideoHDRCodec">
+        <value condition="String.IsEqual(VideoPlayer.HdrType,dolbyvision)">DV</value>
+        <value condition="String.IsEqual(VideoPlayer.HdrType,hdr10)">HDR</value>
+        <value condition="String.IsEqual(VideoPlayer.HdrType,hlg)">HLG</value>
+        <value>SDR</value>
+    </variable>
 
     <variable name="Label_HDRCodec">
         <value condition="String.IsEqual(ListItem.HdrType,dolbyvision)">Dolby Vision</value>
@@ -1106,6 +1117,90 @@
         <value condition="!String.IsEmpty(Container(7000).ListItem.Director)">$INFO[Container(7000).ListItem.Director]</value>
         <value condition="!String.IsEmpty(Container(7000).ListItem.Studio)">$INFO[Container(7000).ListItem.Studio]</value>
         <value condition="!String.IsEmpty(Container(7000).ListItem.Premiered)">$INFO[Container(7000).ListItem.Premiered]</value>
+    </variable>
+	
+    <variable name="Label_VideoPlayer_AudioCodec">
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,aac)">AAC</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,aac_latm)">AAC</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,ac3)">Dolby Digital</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,aif)">AIFF</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,aifc)">AIFF</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,aiff)">AIFF</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,alac)">ALAC</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,ape)">APE</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,avc)">AVC</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,cdda)">CDDA</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,dca)">DTS</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,dolbydigital)">Dolby Digital</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,dts)">DTS</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,dtshd)">DTS-HD</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,dtshd_ma)">DTS-HD MA</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,dtshd_hra)">DTS-HD HRA</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,dtshd_ma_x)">DTS:X MA</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,dtshd_ma_x_imax)">DTS:X (IMAX)</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,eac3)">Dolby Digital+</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,eac3_ddp_atmos)">Dolby Atmos</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,flac)">FLAC</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,mp1)">MP1</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,mp2)">MP2</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,mp3)">MP3</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,mp3float)">MP3</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,ogg)">OGG</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,opus)">OPUS</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,pcm)">PCM</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,pcm_bluray)">PCM</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,pcm_s16le)">PCM</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,pcm_s24le)">PCM</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,truehd)">Dolby TrueHD</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,truehd_atmos)">Dolby Atmos</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,vorbis)">Vorbis</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,wav)">WAV</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,wavpack)">WAVP</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,wmapro)">WMA-PRO</value>
+        <value condition="String.IsEqual(VideoPlayer.AudioCodec,wmav2)">WMA</value>
+        <value condition="String.IsEmpty(VideoPlayer.AudioCodec)">$LOCALIZE[13205]</value>
+    </variable>
+	
+    <variable name="Label_ListItem_AudioCodec">
+        <value condition="String.IsEqual(ListItem.AudioCodec,aac)">AAC</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,aac_latm)">AAC</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,ac3)">DD</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,aif)">AIFF</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,aifc)">AIFF</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,aiff)">AIFF</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,alac)">ALAC</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,ape)">APE</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,avc)">AVC</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,cdda)">CDDA</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,dca)">DTS</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,dolbydigital)">DD</value>
+		<value condition="String.IsEqual(ListItem.AudioCodec,dts)">DTS</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,dtshd)">DTS-HD</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,dtshd_ma)">DTS-HD MA</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,dtshd_hra)">DTS-HD HRA</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,dtshd_ma_x)">DTS:X MA</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,dtshd_ma_x_imax)">DTS:X (IMAX)</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,eac3)">DD+</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,eac3_ddp_atmos)">Dolby Atmos</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,flac)">FLAC</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,mp1)">MP1</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,mp2)">MP2</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,mp3)">MP3</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,mp3float)">MP3</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,ogg)">OGG</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,opus)">OPUS</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,pcm)">PCM</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,pcm_bluray)">PCM</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,pcm_s16le)">PCM</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,pcm_s24le)">PCM</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,truehd)">Dolby TrueHD</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,truehd_atmos)">Dolby Atmos</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,vorbis)">Vorbis</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,wav)">WAV</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,wavpack)">WAVP</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,wmapro)">WMA-PRO</value>
+        <value condition="String.IsEqual(ListItem.AudioCodec,wmav2)">WMA</value>
+        <value condition="String.IsEmpty(ListItem.AudioCodec)">$LOCALIZE[13205]</value>
     </variable>
 
     <variable name="Label_VideoPlayer_AudioChannels">

--- a/1080i/Includes_OSD.xml
+++ b/1080i/Includes_OSD.xml
@@ -479,6 +479,7 @@
             <include content="Info_Line_VideoQuality">
                 <param name="textcolor">panel_fg_90</param>
                 <param name="listitem_videoresolution">VideoPlayer.VideoResolution</param>
+                <param name="listitem_audiocodec">VideoPlayer.AudioCodec</param>
                 <param name="listitem_audiochannels">VideoPlayer.AudioChannels</param>
                 <param name="listitem_hdrtype">VideoPlayer.HdrType</param>
                 <param name="visible">$PARAM[visible]</param>
@@ -827,7 +828,7 @@
                 <centertop>50%</centertop>
                 <height>80</height>
                 <include content="Object_InfoCircle">
-                    <param name="name">[UPPERCASE]$INFO[VideoPlayer.VideoResolution]$INFO[VideoPlayer.VideoCodec, • ,]$INFO[VideoPlayer.VideoAspect, • ,:1]$INFO[VideoPlayer.AudioCodec, • ,]$VAR[Label_VideoPlayer_AudioChannels, • ,][/UPPERCASE]</param>
+                    <param name="name">[UPPERCASE]$INFO[VideoPlayer.VideoResolution]$VAR[Label_OSD_VideoHDRCodec, • ,]$VAR[Label_VideoPlayer_AudioCodec, • ,]$VAR[Label_VideoPlayer_AudioChannels, • ,][/UPPERCASE]</param>
                     <param name="role">$INFO[VideoPlayer.VideoVersionName]</param>
                     <param name="icon">special://skin/extras/icons/photo-film.png</param>
                     <param name="fallback_role">$LOCALIZE[31207]</param>

--- a/extras/tmdbhelper/baseitem.json
+++ b/extras/tmdbhelper/baseitem.json
@@ -29,6 +29,7 @@
     "clearlogo": {"infolabels": ["Art(clearlogo)", "Art(season.clearlogo)", "Art(tvshow.clearlogo)", "Art(artist.clearlogo)"]},
     "videoresolution": {"infolabels": ["videoresolution"]},
     "hdrtype": {"infolabels": ["hdrtype"]},
+    "audiocodec": {"infolabels": ["audiocodec"]},
     "audiochannels": {"infolabels": ["audiochannels"]},
     "hasvideoversions": {"infolabels": ["hasvideoversions"], "function": "boolean"},
     "iscollection": {"infolabels": ["iscollection"], "function": "boolean"},

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -2624,6 +2624,11 @@ msgctxt "#31548"
 msgid "Use detailed status"
 msgstr ""
 
+#: /1080i/Includes_Items.xml /1080i/Includes_Labels.xml
+msgctxt "#31549"
+msgid "Audio codec"
+msgstr ""
+
 #: /1080i/Custom_1115_Dialog_Shortcuts_Window.xml
 msgctxt "#31551"
 msgid "Use as home"


### PR DESCRIPTION
Added audio codec info label as this was somehow still missing.
I wish this could somehow find its way into the skin.
Here are some pictures...

Home Before:
![before](https://github.com/user-attachments/assets/5cdcfd7d-3b53-4c65-8526-1a13711ea93d)

Home After:
![after](https://github.com/user-attachments/assets/342ecb6a-2fcd-4756-93c0-5c8a058937c7)

Dialog info:
![dialoginfo](https://github.com/user-attachments/assets/89ffa128-f768-4c54-938a-b08b0163df5d)

Dialog select:
![dialog select](https://github.com/user-attachments/assets/da5f336c-db03-49af-9656-756578f5d3ed)

Video OSD:
![osd](https://github.com/user-attachments/assets/dce28ba5-e4e3-4bd8-a937-026e04d29acf)

Video OSD 2:
![osd2](https://github.com/user-attachments/assets/25c401d7-818b-4011-8ae5-61dc1fb96eb0)