### PR TITLE
🐛 Fix PVR widget target

### DIFF
--- a/shortcuts/generator/data/setup/widgets_row.xml
+++ b/shortcuts/generator/data/setup/widgets_row.xml
@@ -104,6 +104,22 @@
             <value>{item_target}</value>
         </rule>
         <rule>
+            <condition>{item_path}&lt;&lt;pvr://channels/tv/*?</condition>
+            <value>tvchannels</value>
+        </rule>
+        <rule>
+            <condition>{item_path}&lt;&lt;pvr://recordings</condition>
+            <value>tvrecordings</value>
+        </rule>
+        <rule>
+            <condition>{item_path}&lt;&lt;pvr://timers</condition>
+            <value>tvtimers</value>
+        </rule>               
+        <rule>
+            <condition>{item_path}&lt;&lt;pvr://search</condition>
+            <value>tvsearch</value>
+        </rule>
+        <rule>
             <condition>{item_path}&lt;&lt;pvr://</condition>
             <value>tvguide</value>
         </rule>


### PR DESCRIPTION
Hey Jurial!

Hope you're doing well!

Just to preface this; I have a very limited (probably 0) understanding of PVR in Kodi because I don't use it at all. But someone posted a bug on my GitHub which led me going down this rabbit hole haha!

Although, the [section](https://github.com/jurialmunkey/skin.arctic.fuse.2/blob/f1561b20e61be666053e0f14d1329a2f8f9cec15/shortcuts/skinvariables-shortcut-config.json#L860-L885) here does have the `"node"` pointing to `"tvrecordings"`, clicking on a grouped VOD folder in a widget opened the TV guide instead of opening the folder itself (and to get around this you'd have to call the context menu and select "Browse into" -- turning a simple action into a multi click process).

So after some trial & error I came up with this haha.

This PR does solve the problem now but I'm not sure if it's the "correct" way?

Let me know your thoughts!