### PR TITLE
Localize 'Press down' label in OSD

### DIFF
--- a/1080i/Includes_OSD.xml
+++ b/1080i/Includes_OSD.xml
@@ -86,7 +86,7 @@
                         <textcolor>main_fg_30</textcolor>
                         <width>auto</width>
                         <font>font_tiny_bold</font>
-                        <label>Press $PARAM[arrow_direction]:  </label>
+                        <label>$LOCALIZE[31594]:  </label>
                     </control>
                     <control type="label">
                         <top>-2</top>

--- a/language/resource.language.de_de/strings.po
+++ b/language/resource.language.de_de/strings.po
@@ -2848,3 +2848,8 @@ msgstr "Optionsmenü"
 msgctxt "#31593"
 msgid "Apply your changes?"
 msgstr "Änderungen übernehmen?"
+
+#: /1080i/Includes_OSD.xml
+msgctxt "#31594"
+msgid "Press down"
+msgstr "Nach unten drücken"

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -2848,3 +2848,8 @@ msgstr ""
 msgctxt "#31593"
 msgid "Apply your changes?"
 msgstr ""
+
+#: /1080i/Includes_OSD.xml
+msgctxt "#31594"
+msgid "Press down"
+msgstr ""


### PR DESCRIPTION
- Replaced hardcoded 'Press down' label in Includes_OSD.xml with a localized string (ID 31594). 
- Added corresponding translations for English and German in strings.po files.