### PR TITLE
Add TMDbHelper art to spotlight when PVR channel is detected.

### DIFF
--- a/1080i/Includes_Images.xml
+++ b/1080i/Includes_Images.xml
@@ -169,6 +169,10 @@
         <value condition="!String.IsEmpty(Container(301).ListItem.Art(album.landscape))">$INFO[Container(301).ListItem.Art(album.landscape)]</value>
         <value condition="!String.IsEmpty(Container(301).ListItem.Art(artist.landscape))">$INFO[Container(301).ListItem.Art(artist.landscape)]</value>
         <value condition="!String.IsEmpty(Container(301).ListItem.Art(tvshow.landscape))">$INFO[Container(301).ListItem.Art(tvshow.landscape)]</value>
+        <value condition="!String.IsEmpty(Container(301).ListItem.ChannelNumberLabel) + !String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Fanart))">$INFO[Window(Home).Property(TMDbHelper.ListItem.Fanart)]</value>
+        <value condition="!String.IsEmpty(Container(301).ListItem.ChannelNumberLabel) + !String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.TVShow.Fanart))">$INFO[Window(Home).Property(TMDbHelper.ListItem.TVShow.Fanart)]</value>
+        <value condition="!String.IsEmpty(Container(301).ListItem.ChannelNumberLabel) + !String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Landscape))">$INFO[Window(Home).Property(TMDbHelper.ListItem.Landscape)]</value>
+        <value condition="!String.IsEmpty(Container(301).ListItem.ChannelNumberLabel) + !String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.TVShow.Landscape))">$INFO[Window(Home).Property(TMDbHelper.ListItem.TVShow.Landscape)]</value>
         <value condition="!String.IsEmpty(Container(301).ListItem.EPGEventIcon)">$INFO[Container(301).ListItem.EPGEventIcon]</value>
         <value condition="!String.IsEmpty(Container(301).ListItem.PicturePath)">$INFO[Container(301).ListItem.PicturePath]</value>
         <value condition="String.IsEqual(Container(301).ListItem.DBtype,movie) | String.IsEqual(Container(301).ListItem.DBtype,set)">special://skin/extras/backgrounds/fallbacks/film.jpg</value>


### PR DESCRIPTION
I run ErsatzTV on my network to serve a number of PVR channels.
The spotlight artwork for these channels is low resolution.

<img width="3840" height="2160" alt="Screenshot From 2025-12-03 10-22-39" src="https://github.com/user-attachments/assets/9f6c5cd1-e5ca-4202-86fc-b1a19cd880e5" />
<img width="3840" height="2160" alt="Screenshot From 2025-12-03 10-21-54" src="https://github.com/user-attachments/assets/4edaced0-f8b6-4649-838f-8dd220ee90f4" />

This PR adds TMDBHelper media sources for the spotlight background if the source is a PVR channel.

<img width="3840" height="2160" alt="Screenshot From 2025-12-03 10-25-14" src="https://github.com/user-attachments/assets/177af7af-ba39-4aad-bc05-349fd00c5a02" />
<img width="3840" height="2160" alt="Screenshot From 2025-12-03 11-14-24" src="https://github.com/user-attachments/assets/2fbdb7ef-a3fd-429f-8fc1-b32227495016" />

This is just a suggested implementation, I'm not an expert in Kodi theming. I'd be happy to help if you think this is worthwhile but should be implemented in a different way. My home PVR setup may be different than what everybody else is using, so this may only work in my specific use case.

