### PR TITLE
Add special exception for poster and landscape viewtype images on PVR sources.

### DIFF
--- a/1080i/script-skinvariables-images-includes.xml
+++ b/1080i/script-skinvariables-images-includes.xml
@@ -174,6 +174,7 @@
         <value condition="!String.IsEmpty(Container(450).ListItem.Property(fallback.icon))">$INFO[Container(450).ListItem.Property(fallback.icon)]</value>
     </variable>
     <variable name="Image_Poster">
+        <value condition="String.StartsWith(ListItem.FolderPath,pvr://) + !String.IsEmpty(ListItem.EPGEventIcon)">$INFO[ListItem.EPGEventIcon]</value>
         <value condition="!String.IsEmpty(ListItem.Property(override_poster))">$INFO[ListItem.Property(override_poster)]</value>
         <value condition="!String.IsEmpty(ListItem.Art(poster))">$INFO[ListItem.Art(poster)]</value>
         <value condition="!String.IsEmpty(ListItem.Art(season.poster))">$INFO[ListItem.Art(season.poster)]</value>
@@ -263,6 +264,7 @@
         <value condition="!String.IsEmpty(Container(450).ListItem.Icon)">$INFO[Container(450).ListItem.Icon]</value>
     </variable>
     <variable name="Image_Landscape">
+        <value condition="String.StartsWith(ListItem.FolderPath,pvr://) + !String.IsEmpty(ListItem.EPGEventIcon) +!String.IsEmpty(ListItem.Icon)">$INFO[ListItem.Icon]</value>
         <value condition="String.IsEqual(ListItem.Property(tmdb_type),person)"/>
         <value condition="!String.IsEmpty(ListItem.Property(override_landscape))">$INFO[ListItem.Property(override_landscape)]</value>
         <value condition="[String.IsEqual(ListItem.DBType,episode) | String.IsEqual(ListItem.DBType,video) | String.IsEqual(ListItem.DBType,musicvideo)] + !String.IsEmpty(ListItem.Art(thumb)) + !String.IsEqual(ListItem.Icon,ListItem.Art(fanart)) + !String.IsEqual(ListItem.Icon,OverlaySpoiler.png) + !String.IsEqual(ListItem.Art(thumb),ListItem.Art(poster)) + !String.IsEqual(ListItem.Art(thumb),ListItem.Art(tvshow.poster))">$INFO[ListItem.Art(thumb)]</value>


### PR DESCRIPTION
I run ErsatzTV on my network to serve a number of PVR channels.
When I add a spotlight widget pvr://channels/all/* , the art it is choosing for poster and landscape are wrong.

<img width="3840" height="2160" alt="Screenshot From 2025-12-03 13-02-41" src="https://github.com/user-attachments/assets/721cf12c-8f8d-44c5-9c9b-ff5f5e5c02de" />
<img width="3840" height="2160" alt="Screenshot From 2025-12-03 13-03-27" src="https://github.com/user-attachments/assets/192bb9d4-b49a-4bdb-9eda-b4b3ab32d787" />

The poster viewtype is pulling a good landscape channel image from my PVR server and cropping it.  
The landscape viewtype is pulling a good poster show image from my PVR server and padding it.  

This PR conditionally swaps this when the source is a PVR channel.

<img width="3840" height="2160" alt="Screenshot From 2025-12-03 12-59-51" src="https://github.com/user-attachments/assets/ee6f4646-df26-4640-82e2-8cad9ebba1b2" />

<img width="3840" height="2160" alt="Screenshot From 2025-12-03 13-01-37" src="https://github.com/user-attachments/assets/1a5151e3-ceec-45d5-9158-6631977940d5" />

This is just a suggested implementation, I'm not an expert in Kodi theming. I'd be happy to help if you think this is worthwhile but should be implemented in a different way. My home PVR setup may be different than what everybody else is using, so this may only work in my specific use case.