### PR TITLE
Adds new DefaultSearch items

### DIFF
--- a/shortcuts/generator/data/setup/search_path.xml
+++ b/shortcuts/generator/data/setup/search_path.xml
@@ -25,6 +25,18 @@
             <value>videodb://tvshows/titles/-1/-1/-1/-1/?xsp=%7B%22order%22%3A%7B%22direction%22%3A%22ascending%22%2C%22ignorefolders%22%3A0%2C%22method%22%3A%22sorttitle%22%7D%2C%22rules%22%3A%7B%22and%22%3A%5B%7B%22field%22%3A%22title%22%2C%22operator%22%3A%22contains%22%2C%22value%22%3A%5B%22</value>
         </rule>
         <rule>
+            <condition>{item_path}==DefaultSearch-Plot</condition>
+            <value>videodb://movies/titles/?xsp=%7B%22order%22%3A%7B%22direction%22%3A%22ascending%22%2C%22ignorefolders%22%3A0%2C%22method%22%3A%22sorttitle%22%7D%2C%22rules%22%3A%7B%22and%22%3A%5B%7B%22field%22%3A%22plot%22%2C%22operator%22%3A%22contains%22%2C%22value%22%3A%5B%22</value>
+        </rule>
+        <rule>
+            <condition>{item_path}==DefaultSearch-Tagline</condition>
+            <value>videodb://movies/titles/?xsp=%7B%22order%22%3A%7B%22direction%22%3A%22ascending%22%2C%22ignorefolders%22%3A0%2C%22method%22%3A%22sorttitle%22%7D%2C%22rules%22%3A%7B%22and%22%3A%5B%7B%22field%22%3A%22tagline%22%2C%22operator%22%3A%22contains%22%2C%22value%22%3A%5B%22</value>
+        </rule>
+        <rule>
+            <condition>{item_path}==DefaultSearch-Outline</condition>
+            <value>videodb://movies/titles/?xsp=%7B%22order%22%3A%7B%22direction%22%3A%22ascending%22%2C%22ignorefolders%22%3A0%2C%22method%22%3A%22sorttitle%22%7D%2C%22rules%22%3A%7B%22and%22%3A%5B%7B%22field%22%3A%22plotoutline%22%2C%22operator%22%3A%22contains%22%2C%22value%22%3A%5B%22</value>
+        </rule>
+        <rule>
             <condition>{item_path}==DefaultSearch-Tags</condition>
             <value>videodb://movies/titles/?xsp=%7B%22order%22%3A%7B%22direction%22%3A%22ascending%22%2C%22ignorefolders%22%3A0%2C%22method%22%3A%22sorttitle%22%7D%2C%22rules%22%3A%7B%22and%22%3A%5B%7B%22field%22%3A%22tag%22%2C%22operator%22%3A%22contains%22%2C%22value%22%3A%5B%22</value>
         </rule>
@@ -141,6 +153,10 @@
             <value>plugin://plugin.video.themoviedb.helper?info=search&amp;amp;tmdb_type=person&amp;amp;query=</value>
         </rule>
         <rule>
+            <condition>{item_path}==DefaultSearch-TMDBKeywords</condition>
+            <value>plugin://plugin.video.themoviedb.helper?info=search&amp;amp;tmdb_type=keyword&amp;amp;query=</value>
+        </rule>
+        <rule>
             <condition>{item_path}==DefaultSearch-TMDBListsTrakt</condition>
             <value>plugin://plugin.video.themoviedb.helper?info=trakt_searchlists&amp;amp;tmdb_type=both&amp;amp;query=</value>
         </rule>
@@ -181,6 +197,18 @@
         <rule>
             <condition>{item_path}==DefaultSearch-Episodes</condition>
             <value>%22%5D%7D%5D%7D%2C%22type%22%3A%22episodes%22%7D</value>
+        </rule>
+        <rule>
+            <condition>{item_path}==DefaultSearch-Plot</condition>
+            <value>%22%5D%7D%5D%7D%2C%22type%22%3A%22movies%22%7D</value>
+        </rule>
+        <rule>
+            <condition>{item_path}==DefaultSearch-Tagline</condition>
+            <value>%22%5D%7D%5D%7D%2C%22type%22%3A%22movies%22%7D</value>
+        </rule>
+        <rule>
+            <condition>{item_path}==DefaultSearch-Outline</condition>
+            <value>%22%5D%7D%5D%7D%2C%22type%22%3A%22movies%22%7D</value>
         </rule>
         <rule>
             <condition>{item_path}==DefaultSearch-Tags</condition>
@@ -255,6 +283,10 @@
             <value>&amp;amp;nextpage=false&amp;amp;cacheonly=true</value>
         </rule>
         <rule>
+            <condition>{item_path}==DefaultSearch-TMDBKeywords</condition>
+            <value>&amp;amp;nextpage=false&amp;amp;cacheonly=true</value>
+        </rule>
+        <rule>
             <condition>{item_path}==DefaultSearch-TMDBListsTrakt</condition>
             <value>&amp;amp;nextpage=false&amp;amp;cacheonly=true</value>
         </rule>
@@ -294,6 +326,18 @@
         </rule>
         <rule>
             <condition>{item_path}==DefaultSearch-Episodes</condition>
+            <value>videos</value>
+        </rule>
+        <rule>
+            <condition>{item_path}==DefaultSearch-Plot</condition>
+            <value>videos</value>
+        </rule>
+        <rule>
+            <condition>{item_path}==DefaultSearch-Tagline</condition>
+            <value>videos</value>
+        </rule>
+        <rule>
+            <condition>{item_path}==DefaultSearch-Outline</condition>
             <value>videos</value>
         </rule>
         <rule>
@@ -413,6 +457,10 @@
             <value>videos</value>
         </rule>
         <rule>
+            <condition>{item_path}==DefaultSearch-TMDBKeywords</condition>
+            <value>videos</value>
+        </rule>
+        <rule>
             <condition>{item_path}==DefaultSearch-TMDBListsTrakt</condition>
             <value>videos</value>
         </rule>
@@ -456,6 +504,18 @@
         </rule>
         <rule>
             <condition>{item_path}==DefaultSearch-Episodes</condition>
+            <value>Path_SearchTerm_SingleEncoded</value>
+        </rule>
+        <rule>
+            <condition>{item_path}==DefaultSearch-Plot</condition>
+            <value>Path_SearchTerm_SingleEncoded</value>
+        </rule>
+        <rule>
+            <condition>{item_path}==DefaultSearch-Tagline</condition>
+            <value>Path_SearchTerm_SingleEncoded</value>
+        </rule>
+        <rule>
+            <condition>{item_path}==DefaultSearch-Outline</condition>
             <value>Path_SearchTerm_SingleEncoded</value>
         </rule>
         <rule>
@@ -572,6 +632,10 @@
         </rule>
         <rule>
             <condition>{item_path}==DefaultSearch-TMDBPeople</condition>
+            <value>Path_SearchTerm_DoubleEncoded</value>
+        </rule>
+        <rule>
+            <condition>{item_path}==DefaultSearch-TMDBKeywords</condition>
             <value>Path_SearchTerm_DoubleEncoded</value>
         </rule>
         <rule>

--- a/shortcuts/skinvariables-shortcut-config.json
+++ b/shortcuts/skinvariables-shortcut-config.json
@@ -1,6 +1,5 @@
 {
     "icons": {
-        "DefaultGenre.png": "special://skin/extras/icons/genre.png",
         "DefaultShortcut.png": "special://skin/extras/icons/shortcut.png",
         "Events.png": "special://skin/extras/icons/clipboard.png",
         "DefaultVideo.png": "special://skin/extras/icons/video.png",
@@ -208,6 +207,27 @@
             "link": "true"
         },
         {
+            "name": "Plot",
+            "icon": "special://skin/extras/icons/align-center.png",
+            "path": "DefaultSearch-Plot",
+            "node": "videos",
+            "link": "true"
+        },
+        {
+            "name": "Tagline",
+            "icon": "special://skin/extras/icons/quote.png",
+            "path": "DefaultSearch-Tagline",
+            "node": "videos",
+            "link": "true"
+        },
+        {
+            "name": "Outline",
+            "icon": "special://skin/extras/icons/quote.png",
+            "path": "DefaultSearch-Outline",
+            "node": "videos",
+            "link": "true"
+        },
+        {
             "name": "Tags",
             "icon": "special://skin/extras/icons/tags.png",
             "path": "DefaultSearch-Tags",
@@ -407,6 +427,13 @@
             "name": "TMDb People",
             "icon": "special://skin/extras/icons/person3.png",
             "path": "DefaultSearch-TMDBPeople",
+            "node": "videos",
+            "link": "true"
+        },
+        {
+            "name": "TMDb Keywords",
+            "icon": "special://skin/extras/icons/bookmark-star.png",
+            "path": "DefaultSearch-TMDBKeywords",
             "node": "videos",
             "link": "true"
         },

--- a/shortcuts/skinvariables-shortcut-config.json
+++ b/shortcuts/skinvariables-shortcut-config.json
@@ -432,7 +432,7 @@
         },
         {
             "name": "TMDb Keywords",
-            "icon": "special://skin/extras/icons/bookmark-star.png",
+            "icon": "special://skin/extras/icons/key.png",
             "path": "DefaultSearch-TMDBKeywords",
             "node": "videos",
             "link": "true"


### PR DESCRIPTION
This adds DefaultSearch items that can't be added as a custom ones, for the way they have to be added. It will bring searching for Plot which is something Estuary does, but also also Tagline and the less common Outline from IMDB if people need it.

- DefaultSearch-Plot
- DefaultSearch-Tagline
- DefaultSearch-Outline

I also went ahead and added the **TMDB Keywords** which might be not too common and can be added as a custom search item, but I feel like it was missing from the other TMDB search elements in case someone else wanted it.

I also cleaned the duplicate line:
https://github.com/jurialmunkey/skin.arctic.fuse.2/blob/63f6217267fd1f391f702b78732ba70b3107e066/shortcuts/skinvariables-shortcut-config.json#L3

Thank you.